### PR TITLE
Updated maven to prevent checkstyle error

### DIFF
--- a/druid/Dockerfile
+++ b/druid/Dockerfile
@@ -22,8 +22,8 @@ RUN apt-get update \
       && rm -rf /var/lib/apt/lists/*
 
 # Maven
-RUN wget -q -O - http://archive.apache.org/dist/maven/maven-3/3.2.5/binaries/apache-maven-3.2.5-bin.tar.gz | tar -xzf - -C /usr/local \
-      && ln -s /usr/local/apache-maven-3.2.5 /usr/local/apache-maven \
+RUN wget -q -O - http://archive.apache.org/dist/maven/maven-3/3.3.9/binaries/apache-maven-3.3.9-bin.tar.gz | tar -xzf - -C /usr/local \
+      && ln -s /usr/local/apache-maven-3.3.9 /usr/local/apache-maven \
       && ln -s /usr/local/apache-maven/bin/mvn /usr/local/bin/mvn
 
 # Zookeeper
@@ -53,7 +53,7 @@ RUN mvn -U -B org.codehaus.mojo:versions-maven-plugin:2.1:set -DgenerateBackupPo
   && cp -r distribution/target/hadoop-dependencies /usr/local/druid/ \
   && rm -rf /tmp/* \
             /var/tmp/* \
-            /usr/local/apache-maven-3.2.5 \
+            /usr/local/apache-maven-3.3.9 \
             /usr/local/apache-maven \
             /root/.m2
 


### PR DESCRIPTION
Simple patch to prevent a error with checkstyle:

```sh
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-checkstyle-plugin:3.0.0:check (validate) on project druid: Unable to parse configuration of mojo org.apache.maven.plugins:maven-checkstyle-plugin:3.0.0:check for parameter sourceDirectories: Cannot assign configuration entry 'sourceDirectories' with value '/tmp/druid/src/main/java' of type java.lang.String to property of type java.util.List ->
```